### PR TITLE
Use SID header, instead of the standard Wine SID

### DIFF
--- a/registry_parser.go
+++ b/registry_parser.go
@@ -60,10 +60,11 @@ func (k *RegistryKey) Import(r io.Reader) error {
 				return fmt.Errorf("wine: unexpected path directive")
 			}
 
-			switch path := line[i+1:]; path {
-			case `REGISTRY\\User\\` + sid:
+			switch path := line[i+1:]; {
+			case strings.HasPrefix(path, `REGISTRY\\User\\`) &&
+				path != `REGISTRY\\User\\.Default`:
 				k.Name = "HKEY_CURRENT_USER"
-			case `REGISTRY\\Machine`:
+			case path == `REGISTRY\\Machine`:
 				k.Name = "HKEY_LOCAL_MACHINE"
 			default:
 				return fmt.Errorf("wine: unknown registry path: %s", path)


### PR DESCRIPTION
Proton generates a randomized user SID, so when attempting to run Proton 11.0, this registry code assumes the standard Wine SID `S-1-5-21-0-0-0-1000`,  causing Proton's random SID to hit the `default:` branch, thereby crashing the program

## Fix
Since user.reg is the current user's hive, accepting whatever SID its header declares rather than only the standard Wine SID should fix this issue.

